### PR TITLE
Fix for Addon Manager versions.

### DIFF
--- a/marketshowlevel/src/marketshowlevel/marketshowlevel.lua
+++ b/marketshowlevel/src/marketshowlevel/marketshowlevel.lua
@@ -58,9 +58,11 @@ function GetItemValueColor(value, max)
 end
 
 function MARKETSHOWLEVEL_ON_INIT(addon, frame)
-
-	_G["ON_MARKET_ITEM_LIST"] = ON_MARKET_ITEM_LIST_HOOKED;
-
+	if (acutil ~= nil) then
+		acutil.setupEvent(addon, "ON_MARKET_ITEM_LIST", "ON_MARKET_ITEM_LIST_HOOKED")
+	else
+		_G["ON_MARKET_ITEM_LIST"] = ON_MARKET_ITEM_LIST_HOOKED;
+	end
 end
 
 function ON_MARKET_ITEM_LIST_HOOKED(frame, msg, argStr, argNum)


### PR DESCRIPTION
Fix to accomodate people who manually downloaded the ipf and using Addon Manager, since too many hooks are in place already for a function